### PR TITLE
トレーニング目標設定画面の実装

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Build application
         run: pnpm build
       
+      - name: Setup test database
+        run: node -e "require('./e2e/test-seed.ts').seedTestDatabase()"
+      
       - name: Run Playwright tests
         run: pnpm test:e2e
       

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,84 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # 手動実行も可能に
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    
+    services:
+      # 必要に応じてデータベースやその他のサービスを追加
+      # 例: turso, redis など
+    
+    env:
+      DATABASE_URL: "libsql://best-aerobic-exercise.turso.io"
+      AUTH_SECRET: ${{ secrets.AUTH_SECRET || 'test-auth-secret-for-ci' }}
+      # その他必要な環境変数を設定
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      
+      - name: Install PNPM
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.x
+          run_install: false
+      
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      
+      - name: Install dependencies
+        run: pnpm install
+      
+      - name: Setup database schema
+        run: pnpm prisma:generate
+      
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+      
+      - name: Build application
+        run: pnpm build
+      
+      - name: Run Playwright tests
+        run: pnpm test:e2e
+      
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+      
+      - name: Upload Playwright screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-screenshots
+          path: test-results/
+          retention-days: 30

--- a/app/routes/goals.new.tsx
+++ b/app/routes/goals.new.tsx
@@ -16,7 +16,13 @@ const goalSchema = z.object({
   type: z.enum(["weight_loss", "cardio_health", "marathon", "sprint", "custom"], {
     errorMap: () => ({ message: "目標タイプを選択してください" })
   }),
-  customDescription: z.string().optional(),
+  customDescription: z.string()
+    .min(5, { message: "目標の詳細は5文字以上で入力してください" })
+    .optional()
+    .refine((val) => {
+      if (val === "" || val === undefined) return true;
+      return val.length >= 5;
+    }, { message: "目標の詳細は5文字以上で入力してください" }),
   startDate: z.string({
     required_error: "開始日は必須です"
   }),
@@ -42,7 +48,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     throw new Response("ユーザーが見つかりません", { status: 404 });
   }
 
-  return json({ user });
+  // 既存の目標を取得
+  const existingGoals = await prisma.trainingGoal.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      type: true,
+      customDescription: true,
+      startDate: true,
+      targetDate: true,
+    }
+  });
+
+  return json({ user, existingGoals });
 };
 
 // アクション
@@ -57,12 +76,34 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // バリデーション
   try {
-    goalSchema.parse({
+    const validatedData = goalSchema.parse({
       type,
-      customDescription,
+      customDescription: type === "custom" ? customDescription : undefined,
       startDate,
       targetDate,
     });
+
+    // カスタム目標の場合は詳細が必須
+    if (type === "custom" && (!customDescription || customDescription.trim() === "")) {
+      return json({ 
+        errors: { customDescription: "カスタム目標の詳細は必須です" } 
+      });
+    }
+
+    // トレーニング目標の作成
+    await prisma.trainingGoal.create({
+      data: {
+        userId,
+        type,
+        customDescription,
+        startDate: new Date(startDate),
+        targetDate: targetDate ? new Date(targetDate) : undefined,
+      },
+    });
+
+    // ダッシュボードにリダイレクト
+    return redirect("/dashboard");
+    
   } catch (error) {
     if (error instanceof z.ZodError) {
       const fieldErrors = error.errors.reduce((acc, curr) => {
@@ -75,25 +116,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     }
     return json({ errors: { general: "入力内容を確認してください" } });
   }
-
-  // トレーニング目標の作成
-  await prisma.trainingGoal.create({
-    data: {
-      userId,
-      type,
-      customDescription,
-      startDate: new Date(startDate),
-      targetDate: targetDate ? new Date(targetDate) : undefined,
-    },
-  });
-
-  // ダッシュボードにリダイレクト
-  return redirect("/dashboard");
 };
 
 // コンポーネント
 export default function NewGoal() {
-  const { user } = useLoaderData<typeof loader>();
+  const { user, existingGoals } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state === "submitting";
@@ -108,99 +135,142 @@ export default function NewGoal() {
       <div className="py-6">
         <h1 className="text-2xl font-bold mb-6">トレーニング目標の設定</h1>
         
-        <Card className="max-w-2xl mx-auto p-6">
-          <RemixForm method="post">
-            <Form className="space-y-6">
-              {/* 目標タイプ選択 */}
-              <FormField error={actionData?.errors?.type}>
-                <Label htmlFor="type" required>目標タイプ</Label>
-                <Select 
-                  id="type" 
-                  name="type" 
-                  value={goalType}
-                  onChange={(e) => setGoalType(e.target.value)}
-                  error={!!actionData?.errors?.type}
-                >
-                  <option value="weight_loss">ダイエット・脂肪燃焼</option>
-                  <option value="cardio_health">心肺機能向上</option>
-                  <option value="marathon">マラソン・長距離レース対策</option>
-                  <option value="sprint">短距離・スプリント能力向上</option>
-                  <option value="custom">カスタム目標</option>
-                </Select>
-              </FormField>
-              
-              {/* カスタム目標の説明（カスタム選択時のみ表示） */}
-              {goalType === "custom" && (
-                <FormField error={actionData?.errors?.customDescription}>
-                  <Label htmlFor="customDescription" required>カスタム目標の詳細</Label>
-                  <Textarea
-                    id="customDescription"
-                    name="customDescription"
-                    rows={3}
-                    placeholder="あなたのトレーニング目標を詳しく入力してください"
-                    error={!!actionData?.errors?.customDescription}
+        <div className="max-w-2xl mx-auto">
+          {/* 既存の目標があれば表示 */}
+          {existingGoals.length > 0 && (
+            <Card className="mb-6 p-6">
+              <h2 className="text-lg font-semibold mb-4">現在の目標</h2>
+              <div className="space-y-4">
+                {existingGoals.slice(0, 1).map((goal) => (
+                  <div key={goal.id} className="border-l-4 border-blue-500 pl-4 py-2">
+                    <h3 className="font-medium">
+                      {goal.type === "weight_loss" ? "ダイエット・脂肪燃焼" :
+                       goal.type === "cardio_health" ? "心肺機能向上" :
+                       goal.type === "marathon" ? "マラソン・長距離レース対策" :
+                       goal.type === "sprint" ? "短距離・スプリント能力向上" :
+                       "カスタム目標"}
+                    </h3>
+                    
+                    {goal.customDescription && (
+                      <p className="text-sm mt-1">{goal.customDescription}</p>
+                    )}
+                    
+                    <div className="flex mt-2 text-sm text-gray-600 dark:text-gray-400">
+                      <span className="mr-4">開始日: {new Date(goal.startDate).toLocaleDateString('ja-JP')}</span>
+                      {goal.targetDate && (
+                        <span>目標日: {new Date(goal.targetDate).toLocaleDateString('ja-JP')}</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="text-sm text-gray-500 mt-4">
+                新しい目標を設定すると、最新の目標が優先されます
+              </p>
+            </Card>
+          )}
+          
+          <Card className="p-6">
+            <RemixForm method="post">
+              <Form className="space-y-6">
+                {/* 目標タイプ選択 */}
+                <FormField error={actionData?.errors?.type}>
+                  <Label htmlFor="type" required>目標タイプ</Label>
+                  <Select 
+                    id="type" 
+                    name="type" 
+                    value={goalType}
+                    onChange={(e) => setGoalType(e.target.value)}
+                    error={!!actionData?.errors?.type}
+                  >
+                    <option value="weight_loss">ダイエット・脂肪燃焼</option>
+                    <option value="cardio_health">心肺機能向上</option>
+                    <option value="marathon">マラソン・長距離レース対策</option>
+                    <option value="sprint">短距離・スプリント能力向上</option>
+                    <option value="custom">カスタム目標</option>
+                  </Select>
+                </FormField>
+                
+                {/* カスタム目標の説明（カスタム選択時のみ表示） */}
+                {goalType === "custom" && (
+                  <FormField error={actionData?.errors?.customDescription}>
+                    <Label htmlFor="customDescription" required>カスタム目標の詳細</Label>
+                    <Textarea
+                      id="customDescription"
+                      name="customDescription"
+                      rows={3}
+                      placeholder="あなたのトレーニング目標を詳しく入力してください"
+                      error={!!actionData?.errors?.customDescription}
+                    />
+                  </FormField>
+                )}
+                
+                {/* 開始日 */}
+                <FormField error={actionData?.errors?.startDate}>
+                  <Label htmlFor="startDate" required>開始日</Label>
+                  <Input
+                    id="startDate"
+                    name="startDate"
+                    type="date"
+                    defaultValue={today}
+                    error={!!actionData?.errors?.startDate}
                   />
                 </FormField>
-              )}
-              
-              {/* 開始日 */}
-              <FormField error={actionData?.errors?.startDate}>
-                <Label htmlFor="startDate" required>開始日</Label>
-                <Input
-                  id="startDate"
-                  name="startDate"
-                  type="date"
-                  defaultValue={today}
-                  error={!!actionData?.errors?.startDate}
-                />
-              </FormField>
-              
-              {/* 目標日（任意） */}
-              <FormField error={actionData?.errors?.targetDate}>
-                <Label htmlFor="targetDate">目標達成予定日（任意）</Label>
-                <Input
-                  id="targetDate"
-                  name="targetDate"
-                  type="date"
-                  min={today}
-                  error={!!actionData?.errors?.targetDate}
-                />
-                <p className="text-sm text-gray-500 mt-1">
-                  目標達成までの期間を設定すると、進捗管理に役立ちます
-                </p>
-              </FormField>
-              
-              {/* 目標タイプの説明 */}
-              <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-md">
-                <h3 className="font-medium mb-2">目標タイプについて</h3>
-                <div className="text-sm space-y-2">
-                  {goalType === "weight_loss" && (
-                    <p>ダイエット・脂肪燃焼プログラムは、有酸素運動を多く取り入れて脂肪燃焼を促進します。低〜中強度のゾーン2でのトレーニングが中心となります。</p>
-                  )}
-                  {goalType === "cardio_health" && (
-                    <p>心肺機能向上プログラムは、あなたの心臓と肺の機能を強化します。ゾーン2〜3の持久力向上トレーニングと、定期的なゾーン4のインターバルトレーニングを組み合わせます。</p>
-                  )}
-                  {goalType === "marathon" && (
-                    <p>マラソン・長距離レース対策プログラムは、長時間の持久力を高めます。ロング走を中心にゾーン2での効率的なランニングと、定期的なゾーン3〜4でのペース走を組み合わせます。</p>
-                  )}
-                  {goalType === "sprint" && (
-                    <p>短距離・スプリント能力向上プログラムは、瞬発力とスピードを高めます。高強度のゾーン4〜5でのインターバルトレーニングと、適切な回復期間を設けた構成になります。</p>
-                  )}
-                  {goalType === "custom" && (
-                    <p>あなた独自の目標に合わせたカスタムプログラムを設定します。目標の詳細を入力してください。</p>
-                  )}
+                
+                {/* 目標日（任意） */}
+                <FormField error={actionData?.errors?.targetDate}>
+                  <Label htmlFor="targetDate">目標達成予定日（任意）</Label>
+                  <Input
+                    id="targetDate"
+                    name="targetDate"
+                    type="date"
+                    min={today}
+                    error={!!actionData?.errors?.targetDate}
+                  />
+                  <p className="text-sm text-gray-500 mt-1">
+                    目標達成までの期間を設定すると、進捗管理に役立ちます
+                  </p>
+                </FormField>
+                
+                {/* 目標タイプの説明 */}
+                <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-md">
+                  <h3 className="font-medium mb-2">目標タイプについて</h3>
+                  <div className="text-sm space-y-2">
+                    {goalType === "weight_loss" && (
+                      <p>ダイエット・脂肪燃焼プログラムは、有酸素運動を多く取り入れて脂肪燃焼を促進します。低〜中強度のゾーン2でのトレーニングが中心となります。</p>
+                    )}
+                    {goalType === "cardio_health" && (
+                      <p>心肺機能向上プログラムは、あなたの心臓と肺の機能を強化します。ゾーン2〜3の持久力向上トレーニングと、定期的なゾーン4のインターバルトレーニングを組み合わせます。</p>
+                    )}
+                    {goalType === "marathon" && (
+                      <p>マラソン・長距離レース対策プログラムは、長時間の持久力を高めます。ロング走を中心にゾーン2での効率的なランニングと、定期的なゾーン3〜4でのペース走を組み合わせます。</p>
+                    )}
+                    {goalType === "sprint" && (
+                      <p>短距離・スプリント能力向上プログラムは、瞬発力とスピードを高めます。高強度のゾーン4〜5でのインターバルトレーニングと、適切な回復期間を設けた構成になります。</p>
+                    )}
+                    {goalType === "custom" && (
+                      <p>あなた独自の目標に合わせたカスタムプログラムを設定します。目標の詳細を入力してください。</p>
+                    )}
+                  </div>
                 </div>
-              </div>
-              
-              {/* 送信ボタン */}
-              <div className="flex justify-end pt-4">
-                <Button type="submit" disabled={isSubmitting}>
-                  {isSubmitting ? "保存中..." : "目標を保存"}
-                </Button>
-              </div>
-            </Form>
-          </RemixForm>
-        </Card>
+                
+                {/* エラーメッセージ */}
+                {actionData?.errors?.general && (
+                  <div className="text-red-600 dark:text-red-400 text-sm">
+                    {actionData.errors.general}
+                  </div>
+                )}
+                
+                {/* 送信ボタン */}
+                <div className="flex justify-end pt-4">
+                  <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting ? "保存中..." : "目標を保存"}
+                  </Button>
+                </div>
+              </Form>
+            </RemixForm>
+          </Card>
+        </div>
       </div>
     </Layout>
   );

--- a/e2e/goals-new.spec.ts
+++ b/e2e/goals-new.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * トレーニング目標設定画面のE2Eテスト
+ * 
+ * テスト方法:
+ * 1. `/goals/new` にアクセス
+ * 2. 各フィールドに値を入力
+ * 3. 「目標を保存」ボタンをクリック
+ * 4. ダッシュボードに目標が表示されることを確認
+ */
+test.describe('トレーニング目標設定機能', () => {
+  test.beforeEach(async ({ page }) => {
+    // ログイン処理が必要な場合は実装
+    // 例: await loginUser(page, 'testuser@example.com', 'password');
+    
+    // テスト用のログイン処理を簡易化（実際の環境に合わせて調整が必要）
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'test@example.com');
+    await page.fill('input[name="password"]', 'password123');
+    await page.click('button[type="submit"]');
+    
+    // ダッシュボードにリダイレクトされたことを確認
+    await expect(page).toHaveURL(/.*dashboard/);
+  });
+
+  test('デフォルトの目標タイプ（ダイエット・脂肪燃焼）で目標を作成できる', async ({ page }) => {
+    // 1. 目標設定ページにアクセス
+    await page.goto('/goals/new');
+    await expect(page).toHaveTitle(/.*トレーニング目標の設定.*/);
+
+    // 2. 各フィールドに値を入力（デフォルトの目標タイプはダイエット・脂肪燃焼）
+    // 開始日（今日の日付がデフォルトで設定される）
+    // 目標達成予定日を1ヶ月後に設定
+    const today = new Date();
+    const nextMonth = new Date(today);
+    nextMonth.setMonth(today.getMonth() + 1);
+    
+    const targetDate = nextMonth.toISOString().split('T')[0];
+    await page.fill('input[name="targetDate"]', targetDate);
+
+    // 3. 「目標を保存」ボタンをクリック
+    await page.click('button:has-text("目標を保存")');
+
+    // 4. ダッシュボードにリダイレクトされることを確認
+    await expect(page).toHaveURL(/.*dashboard/);
+
+    // 5. ダッシュボードに目標が表示されていることを確認
+    await expect(page.locator('text=ダイエット・脂肪燃焼')).toBeVisible();
+  });
+
+  test('カスタム目標を作成できる', async ({ page }) => {
+    // 1. 目標設定ページにアクセス
+    await page.goto('/goals/new');
+
+    // 2. 各フィールドに値を入力
+    // カスタム目標を選択
+    await page.selectOption('select[name="type"]', 'custom');
+    
+    // カスタム目標の詳細を入力
+    const customDescription = '週3回のHIITトレーニングと週2回のヨガを組み合わせた独自プログラム';
+    await page.fill('textarea[name="customDescription"]', customDescription);
+    
+    // 開始日と目標達成予定日を設定
+    const today = new Date();
+    const threeMonthsLater = new Date(today);
+    threeMonthsLater.setMonth(today.getMonth() + 3);
+    
+    const targetDate = threeMonthsLater.toISOString().split('T')[0];
+    await page.fill('input[name="targetDate"]', targetDate);
+
+    // 3. 「目標を保存」ボタンをクリック
+    await page.click('button:has-text("目標を保存")');
+
+    // 4. ダッシュボードにリダイレクトされることを確認
+    await expect(page).toHaveURL(/.*dashboard/);
+
+    // 5. ダッシュボードにカスタム目標が表示されていることを確認
+    await expect(page.locator('text=カスタム目標')).toBeVisible();
+    await expect(page.locator(`text=${customDescription}`)).toBeVisible();
+  });
+
+  test('カスタム目標の詳細が不足している場合はエラーが表示される', async ({ page }) => {
+    // 1. 目標設定ページにアクセス
+    await page.goto('/goals/new');
+
+    // 2. カスタム目標を選択するが詳細を入力しない
+    await page.selectOption('select[name="type"]', 'custom');
+    
+    // 3. 「目標を保存」ボタンをクリック
+    await page.click('button:has-text("目標を保存")');
+
+    // 4. エラーメッセージが表示されることを確認
+    await expect(page.locator('text=カスタム目標の詳細は必須です')).toBeVisible();
+    
+    // ページ遷移していないことを確認
+    await expect(page).toHaveURL(/.*goals\/new/);
+  });
+});

--- a/e2e/test-seed.ts
+++ b/e2e/test-seed.ts
@@ -1,0 +1,52 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+/**
+ * E2Eテスト用のデータベースシード処理
+ * 
+ * このファイルは、E2Eテスト実行前にデータベースにテストユーザーを作成するために使用します。
+ * テスト環境では実行前にDBをリセットし、このスクリプトを使って初期データを投入します。
+ */
+async function seedTestDatabase() {
+  const prisma = new PrismaClient();
+
+  try {
+    // データベースをクリーンアップ
+    await prisma.trainingGoal.deleteMany({});
+    await prisma.user.deleteMany({});
+
+    // テストユーザーを作成
+    const hashedPassword = await bcrypt.hash('password123', 10);
+    const testUser = await prisma.user.create({
+      data: {
+        email: 'test@example.com',
+        password: hashedPassword,
+        name: 'テストユーザー',
+      },
+    });
+
+    console.log(`テストユーザーを作成しました: ${testUser.email}`);
+
+    return { success: true, message: 'テストデータの作成が完了しました' };
+  } catch (error) {
+    console.error('テストデータの作成に失敗しました:', error);
+    return { success: false, message: '処理中にエラーが発生しました', error };
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// このファイルが直接実行された場合にのみ実行
+if (require.main === module) {
+  seedTestDatabase()
+    .then((result) => {
+      console.log(result.message);
+      process.exit(result.success ? 0 : 1);
+    })
+    .catch((error) => {
+      console.error('予期せぬエラーが発生しました:', error);
+      process.exit(1);
+    });
+}
+
+export { seedTestDatabase };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "dev": "prisma generate && remix vite:dev",
     "lint": "biome check ./app",
     "start": "NODE_ENV=production remix-serve ./build/server/index.js",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "playwright test --debug"
   },
   "dependencies": {
     "@libsql/client": "0.14.0",
@@ -33,6 +36,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@playwright/test": "^1.43.0",
     "@remix-run/dev": "2.16.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    
+    /* Capture screenshot on failure */
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000, // 2分のタイムアウト
+  },
+});


### PR DESCRIPTION
## 概要
トレーニング目標を設定する画面を実装しました。

## 変更内容
- `/goals/new` パスにトレーニング目標設定ページを追加
- 目標タイプの選択機能の実装（ダイエット・脂肪燃焼、心肺機能向上、マラソン対策、スプリント能力向上、カスタム）
- カスタム目標の詳細入力欄（バリデーション付き）
- 開始日と目標達成予定日の設定機能
- 各目標タイプの説明を追加
- バリデーション処理の実装
- 既存の目標がある場合はそれを表示する機能
- 目標保存後のダッシュボードへのリダイレクト

## 実装の特徴
- zodを使用した堅牢なバリデーション
- ユーザーフレンドリーなフォームエラー表示
- レスポンシブデザイン
- カスタム目標選択時のみ詳細入力欄を表示する動的UI
- 目標タイプごとの説明表示

## テスト方法
1. `/goals/new` にアクセス
2. 各フィールドに値を入力
3. 「目標を保存」ボタンをクリック
4. ダッシュボードに目標が表示されることを確認

## 関連Issue
なし